### PR TITLE
configuration of blobstore server side encryption with variables

### DIFF
--- a/operations/s3-blobstore.yml
+++ b/operations/s3-blobstore.yml
@@ -2,7 +2,7 @@
 
 - type: replace
   path: /instance_groups/name=bosh/properties/blobstore/server_side_encryption?
-  value: AES256
+  value: ((blobstore.server_side_encryption))
 - type: replace
   path: /instance_groups/name=bosh/properties/blobstore/bucket_name?
   value: ((terraform_outputs.bosh_blobstore_bucket))
@@ -21,4 +21,4 @@
       bucket_name: ((terraform_outputs.bosh_blobstore_bucket))
       region: ((terraform_outputs.vpc_region))
       credentials_source: env_or_profile
-      server_side_encryption: AES256
+      server_side_encryption: ((blobstore.server_side_encryption))

--- a/variables/development.yml
+++ b/variables/development.yml
@@ -5,3 +5,5 @@ network: development-bosh
 instance_profile: development-bosh-profile
 gateway_host: prometheus-staging.service.cf.internal
 gateway_deployment: ""
+blobstore:
+  server_side_encryption: "aws:kms"

--- a/variables/production.yml
+++ b/variables/production.yml
@@ -5,3 +5,5 @@ network: production-bosh
 instance_profile: production-bosh-profile
 gateway_host: prometheus-production.service.cf.internal
 gateway_deployment: ""
+blobstore:
+  server_side_encryption: "AES256"

--- a/variables/staging.yml
+++ b/variables/staging.yml
@@ -5,3 +5,5 @@ network: staging-bosh
 instance_profile: staging-bosh-profile
 gateway_host: prometheus-staging.service.cf.internal
 gateway_deployment: ""
+blobstore:
+  server_side_encryption: "AES256"

--- a/variables/tooling.yml
+++ b/variables/tooling.yml
@@ -5,3 +5,5 @@ network: bosh
 instance_profile: bosh-profile
 gateway_host: prometheus-tooling.service.cf.internal
 gateway_deployment: prometheus-production
+blobstore:
+  server_side_encryption: "AES256"


### PR DESCRIPTION
## Changes proposed in this pull request:

Enables the configuration of blobstore server side encryption through variables. This will enable the test and rollout of KMS encryption for the bosh blobstores.

## security considerations

KMS encryption is required for FIPS 140 compliance. 

