### PR TITLE
Require IMDSv2

### DIFF
--- a/operations/cpi.yml
+++ b/operations/cpi.yml
@@ -21,3 +21,12 @@
 - type: replace
   path: /tags?/environment?
   value: ((environment))
+
+# Forces IMDSv2
+- type: replace
+  path: /instance_groups/name=bosh/properties/aws/metadata_options?/http_tokens?
+  value: required
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/aws/metadata_options?/http_put_response_hop_limit?
+  value: 2


### PR DESCRIPTION
## Changes proposed in this pull request:
- Require IMDSv2 for all vms created by each bosh director
- Tested against CF staging and passes smoke and acceptance tests.
- A similar configuration already exists on diego cells and both flavors concourse workers
- Part of https://github.com/cloud-gov/private/issues/1911

## security considerations
Forces the use of a token to access metadata information
