### PR TITLE
Adding IMDSv2 to masterbosh

### DIFF
--- a/bosh-create-env.sh
+++ b/bosh-create-env.sh
@@ -18,6 +18,7 @@ bosh create-env \
   --ops-file bosh-deployment/credhub.yml \
   --ops-file bosh-deployment/jumpbox-user.yml \
   --ops-file bosh-config/operations/cpi.yml \
+  --ops-file bosh-config/operations/masterbosh-metadatav2.yml \
   --ops-file bosh-config/operations/encryption.yml \
   --ops-file bosh-config/operations/add-cloud-gov-root-certificate.yml \
   --ops-file bosh-config/operations/masterbosh-ntp.yml \

--- a/operations/masterbosh-metadatav2.yml
+++ b/operations/masterbosh-metadatav2.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /cloud_provider/properties/aws/metadata_options?/http_tokens?
+  value: required
+
+- type: replace
+  path: /cloud_provider/properties/aws/metadata_options?/http_put_response_hop_limit?
+  value: 2


### PR DESCRIPTION
## Changes proposed in this pull request:
- Require IMDSv2 for the masterbosh director
- The rest of the bosh directors were solved with: https://github.com/cloud-gov/deploy-bosh/pull/625
- Part of https://github.com/cloud-gov/private/issues/1911

## security considerations
Forces the use of a token to access metadata information
