### PR TITLE
Remove meta-data-v2 extension

### DIFF
--- a/cloud-config/base.yml
+++ b/cloud-config/base.yml
@@ -520,11 +520,6 @@ vm_types:
   name: x1e.xlarge
 
 vm_extensions:
-- cloud_properties:
-    metadata_options:
-      http_tokens: required
-      http_put_response_hop_limit: 2
-  name: meta-data-v2
 - name: errand-profile
   cloud_properties:
     iam_instance_profile: ((terraform_outputs.bosh_compilation_profile))


### PR DESCRIPTION
## Changes proposed in this pull request:
- Require IMDSv2 for all vms created by each bosh director, this removes the vm_extension in the cloud_config which was used to enable IMDSv2 only for a small subset of vms since this is configured globally.
- Part of https://github.com/cloud-gov/private/issues/1911

## security considerations
Forces the use of a token to access metadata information
