### PR TITLE
Removed unneeded blobstore certs since we use S3

### DIFF
--- a/operations/s3-blobstore-protobosh.yml
+++ b/operations/s3-blobstore-protobosh.yml
@@ -42,3 +42,9 @@
       region: ((terraform_outputs.vpc_region))
       credentials_source: env_or_profile
       server_side_encryption: AES256
+
+- type: remove
+  path: /variables/name=blobstore_ca?
+
+- type: remove
+  path: /variables/name=blobstore_server_tls?

--- a/operations/s3-blobstore.yml
+++ b/operations/s3-blobstore.yml
@@ -22,3 +22,9 @@
       region: ((terraform_outputs.vpc_region))
       credentials_source: env_or_profile
       server_side_encryption: ((blobstore.server_side_encryption))
+
+- type: remove
+  path: /variables/name=blobstore_ca?
+
+- type: remove
+  path: /variables/name=blobstore_server_tls?


### PR DESCRIPTION
## Changes proposed in this pull request:
- Matching https://github.com/cloudfoundry/bosh-deployment/blob/master/aws/s3-blobstore-instance-profile.yml
- Less Certs to worry about that we do not use
-

## security considerations
None, reduces maintenance and unused resources