### PR TITLE
chore: update to official node-exporter-release

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -943,7 +943,7 @@ resources:
 - name: node-exporter-release
   type: bosh-io-release
   source:
-    repository: cloudfoundry-community/node-exporter-boshrelease
+    repository: cloudfoundry/node-exporter-boshrelease
 
 - name: terraform-yaml-tooling
   type: s3-iam


### PR DESCRIPTION
now that node-exporter-release is available as an official release, we should use it

## Changes proposed in this pull request:
- update to official node-exporter-release


## security considerations
This improves security by allowing us to stay up-to-date on node-exporter while avoiding the issues with the cf-community org