### PR TITLE
build wazuh agent in release repo

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -40,6 +40,3 @@ releases:
 - name: aide
   uri: https://github.com/cloud-gov/aide-boshrelease
   branch: main
-- name: wazuh-agent
-  uri: https://github.com/cloud-gov/wazuh-agent
-  branch: main


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes the wazuh agent configuration in favor of a pipeline in the agent bosh release repo.

## security considerations

- No impact. 
