### PR TITLE
Adding root-disk.yml ops file

### DIFF
--- a/cloud-config/root-disk.yml
+++ b/cloud-config/root-disk.yml
@@ -1,0 +1,64 @@
+- type: replace
+  path: /vm_extensions/-
+  value:
+    cloud_properties:
+      root_disk:
+        size: 10240
+    name: 10GB_root_disk
+
+- type: replace
+  path: /vm_extensions/-
+  value:
+    cloud_properties:
+      root_disk:
+        size: 15360
+    name: 15GB_root_disk
+
+
+- type: replace
+  path: /vm_extensions/-
+  value:
+    cloud_properties:
+      root_disk:
+        size: 20480
+    name: 20GB_root_disk
+
+- type: replace
+  path: /vm_extensions/-
+  value:
+    cloud_properties:
+      root_disk:
+        size: 30720
+    name: 30GB_root_disk
+
+- type: replace
+  path: /vm_extensions/-
+  value:
+    cloud_properties:
+      root_disk:
+        size: 40960
+    name: 40GB_root_disk
+
+- type: replace
+  path: /vm_extensions/-
+  value:
+    cloud_properties:
+      root_disk:
+        size: 51200
+    name: 50GB_root_disk
+
+- type: replace
+  path: /vm_extensions/-
+  value:
+    cloud_properties:
+      root_disk:
+        size: 102400
+    name: 100GB_root_disk
+
+- type: replace
+  path: /vm_extensions/-
+  value:
+    cloud_properties:
+      root_disk:
+        size: 204800
+    name: 200GB_root_disk


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds an opsfile which will allow root disk size overrides to be added to the BOSH Cloud Config
- Part of https://github.com/cloud-gov/private/issues/2250
-

## security considerations
None, this adds another ops file that will make available overrides for the default 5GB root disk size
