### PR TITLE
Add root-disk.yml ops file to dev/stage cc

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -422,7 +422,7 @@ jobs:
     image: general-task
     file: bosh-config/ci/update-cloud-config.yml
     params:
-      OPS_PATHS: "bosh-config/cloud-config/main.yml bosh-config/cloud-config/cf.yml bosh-config/cloud-config/development.yml"
+      OPS_PATHS: "bosh-config/cloud-config/main.yml bosh-config/cloud-config/cf.yml bosh-config/cloud-config/development.yml bosh-config/cloud-config/root-disk.yml"
       BOSH_CA_CERT: ((common_ca_cert_store))
       BOSH_ENVIRONMENT: ((developmentbosh-target))
       BOSH_CLIENT: ci
@@ -560,7 +560,7 @@ jobs:
     image: general-task
     file: bosh-config/ci/update-cloud-config.yml
     params:
-      OPS_PATHS: "bosh-config/cloud-config/main.yml bosh-config/cloud-config/cf.yml bosh-config/cloud-config/staging.yml"
+      OPS_PATHS: "bosh-config/cloud-config/main.yml bosh-config/cloud-config/cf.yml bosh-config/cloud-config/staging.yml bosh-config/cloud-config/root-disk.yml"
       BOSH_CA_CERT: ((common_ca_cert_store))
       BOSH_ENVIRONMENT: ((stagingbosh-target))
       BOSH_CLIENT: ci


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds using the `root-disk.yml` ops file to the cloud config for staging and development
- Is the second half of https://github.com/cloud-gov/deploy-bosh/pull/634
- Part of https://github.com/cloud-gov/private/issues/2250

## security considerations
Catches the pipeline.yml up to what is currently deployed, no changes to secrets.
