### PR TITLE
Adding postgres-client release

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -40,3 +40,6 @@ releases:
 - name: aide
   uri: https://github.com/cloud-gov/aide-boshrelease
   branch: main
+- name: postgres-client
+  uri: https://github.com/cloud-gov/postgres-client-boshrelease
+  branch: main


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adding new bosh release for psql client to be later co-located on bosh directors.  This version supports SSL.
- Part of https://github.com/cloud-gov/private/issues/2394
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This is needed to support psql client connections from the BOSH directors running cron jobs to use SSL to connect to RDS.

