### PR TITLE
Adding services_subnet_cidr_az2

### DIFF
--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -42,6 +42,19 @@
         subnet: ((terraform_outputs.services_subnet_az1))
         security_groups:
         - ((terraform_outputs.bosh_security_group))
+    - az: z2
+      range: ((terraform_outputs.services_subnet_cidr_az2))
+      gateway: ((terraform_outputs.services_subnet_gateway_az2))
+      reserved:
+      - ((terraform_outputs.services_subnet_reserved_az2))
+      - ((terraform_outputs.domains-internal-ip-az2))
+      dns: [((terraform_outputs.vpc_cidr_dns))]
+      cloud_properties:
+        subnet: ((terraform_outputs.services_subnet_az2))
+        security_groups:
+        - ((terraform_outputs.bosh_security_group))
+
+
 
 - type: replace
   path: /disk_types/-


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds z2 availability zone to the `services` network to the cloud-config for dev/stage/prod directors
- Will allow the opensearch and logsearch deployments to be multi-az
- Part of https://github.com/cloud-gov/private/issues/2469


## security considerations
Same security group as z1
