### PR TITLE
Rollback concourse az2

### DIFF
--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -47,57 +47,32 @@
     name: staging-concourse
     type: manual
     subnets:
-      - range: ((terraform_outputs.staging_concourse_subnet_cidr_az1))
-        gateway: ((terraform_outputs.staging_concourse_subnet_gateway_az1))
+      - range: ((terraform_outputs.staging_concourse_subnet_cidr))
+        gateway: ((terraform_outputs.staging_concourse_subnet_gateway))
         reserved:
-          - ((terraform_outputs.staging_concourse_subnet_reserved_az1))
+          - ((terraform_outputs.staging_concourse_subnet_reserved))
         az: z2
         dns: [((terraform_outputs.vpc_cidr_dns))]
         cloud_properties:
-          subnet: ((terraform_outputs.staging_concourse_subnet_az1))
+          subnet: ((terraform_outputs.staging_concourse_subnet))
           security_groups:
             - ((terraform_outputs.bosh_security_group))
             - ((terraform_outputs.staging_concourse_security_group))
             - ((terraform_outputs.staging_credhub_security_group))
-      - range: ((terraform_outputs.staging_concourse_subnet_cidr_az2))
-        gateway: ((terraform_outputs.staging_concourse_subnet_gateway_az2))
-        reserved:
-          - ((terraform_outputs.staging_concourse_subnet_reserved_az2))
-        az: z1 # Yes, this looks backwards, it is not
-        dns: [((terraform_outputs.vpc_cidr_dns))]
-        cloud_properties:
-          subnet: ((terraform_outputs.staging_concourse_subnet_az2))
-          security_groups:
-            - ((terraform_outputs.bosh_security_group))
-            - ((terraform_outputs.staging_concourse_security_group))
-            - ((terraform_outputs.staging_credhub_security_group))
-
 - type: replace
   path: /networks/-
   value:
     name: production-concourse
     type: manual
     subnets:
-      - range: ((terraform_outputs.production_concourse_subnet_cidr_az1))
-        gateway: ((terraform_outputs.production_concourse_subnet_gateway_az1))
+      - range: ((terraform_outputs.production_concourse_subnet_cidr))
+        gateway: ((terraform_outputs.production_concourse_subnet_gateway))
         reserved:
-          - ((terraform_outputs.production_concourse_subnet_reserved_az1))
+          - ((terraform_outputs.production_concourse_subnet_reserved))
         az: z1
         dns: [((terraform_outputs.vpc_cidr_dns))]
         cloud_properties:
-          subnet: ((terraform_outputs.production_concourse_subnet_az1))
-          security_groups:
-            - ((terraform_outputs.bosh_security_group))
-            - ((terraform_outputs.production_concourse_security_group))
-            - ((terraform_outputs.production_credhub_security_group))
-      - range: ((terraform_outputs.production_concourse_subnet_cidr_az2))
-        gateway: ((terraform_outputs.production_concourse_subnet_gateway_az2))
-        reserved:
-          - ((terraform_outputs.production_concourse_subnet_reserved_az2))
-        az: z2
-        dns: [((terraform_outputs.vpc_cidr_dns))]
-        cloud_properties:
-          subnet: ((terraform_outputs.production_concourse_subnet_az2))
+          subnet: ((terraform_outputs.production_concourse_subnet))
           security_groups:
             - ((terraform_outputs.bosh_security_group))
             - ((terraform_outputs.production_concourse_security_group))


### PR DESCRIPTION
## Changes proposed in this pull request:
- Rollback concourse az2, needs more vpc peering work and need to unblock stemcell rollout
- Part of https://github.com/cloud-gov/private/issues/2469
-

## security considerations
None, rolls back to previous configuration
