### PR TITLE
Change prometheus-large-disk to 1.2TB gp3

### DIFF
--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -572,10 +572,7 @@
   value:
     <<: *prometheus-large-disk
     name: production-prometheus-large
-    disk_size: 3_000_000
-    cloud_properties:
-      type: io1
-      iops: 14_000
+    disk_size: 1_200_000
 
 - type: replace
   path: /disk_types/-


### PR DESCRIPTION
## Changes proposed in this pull request:
- Change prometheus-large-disk to 1.2TB gp3
- Current config uses io1 disk with 14k iops
- Verified via grafana that the iops used fall in the range of gp3 iops at 3k
- Also scaling disk down to 2x-ish what is currently used
- Part of https://github.com/cloud-gov/private/issues/2594

## security considerations
None, changes a disk pool size and type for 1 vm
