### PR TITLE
Remove awslogs from BOSH runtime

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -250,6 +250,7 @@ jobs:
       - bosh-config/operations/add-cloud-gov-root-certificate.yml
       - bosh-config/operations/nats-payload.yml
       - bosh-config/operations/root-disk.yml
+      - bosh-config/operations/tooling-bosh-awslogs.yml
       vars_files:
       - bosh-config/variables/tooling.yml
       - terraform-secrets/terraform.yml

--- a/operations/tooling-bosh-awslogs.yml
+++ b/operations/tooling-bosh-awslogs.yml
@@ -1,0 +1,26 @@
+# Keeping a stubbed version of the release for tooling bosh, the aws cli is used for cron.yml
+# and uses the version packaged in this release.  For now, tooling bosh will be the only vm with
+# awslogs until a replacement for the aws cli is created.
+
+- type: replace
+  path: /releases/-
+  value:
+    name: awslogs-jammy
+    version: latest
+
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/-
+  value:
+    name: awslogs-jammy
+    release: awslogs-jammy
+    properties:
+      awslogs-jammy:
+        region: us-gov-west-1
+        awslogs_files_config:
+        - name: /var/log/audit/audit.log
+          file: /var/log/audit/audit.log
+          log_group_name: /var/log/audit/audit.log
+          log_stream_name: "{{instance_id}}"
+          initial_position: start_of_file
+          datetime_format: "%Y-%m-%dT%H:%M:%S"

--- a/runtime-config/runtime.yml
+++ b/runtime-config/runtime.yml
@@ -3,7 +3,6 @@ releases:
 - {name: aide, version: ((release_aide))}
 - {name: clamav, version: ((release_clamav))}
 - {name: jammy-snort, version: ((release_jammy_snort))}
-- {name: awslogs-jammy, version: ((release_awslogs_jammy))}
 - {name: nessus-agent, version: ((release_nessus_agent))}
 - {name: node-exporter, version: ((release_node_exporter))}
 - {name: syslog, version: ((release_syslog))}
@@ -48,36 +47,7 @@ addons:
         group: ((/nessus_agent_group))
         server: ((terraform_outputs.nessus_static_ip))
         port: 8834
-  - name: awslogs-jammy
-    release: awslogs-jammy
-    properties:
-      awslogs-jammy:
-        region: us-gov-west-1
-        awslogs_files_config:
-        - name: /var/log/audit/audit.log
-          file: /var/log/audit/audit.log
-          log_group_name: /var/log/audit/audit.log
-          log_stream_name: "{{instance_id}}"
-          initial_position: start_of_file
-          datetime_format: "%Y-%m-%dT%H:%M:%S"
-        - name: /var/log/auth.log
-          file: /var/log/auth.log
-          log_group_name: /var/log/auth.log
-          log_stream_name: "{{instance_id}}"
-          initial_position: start_of_file
-          datetime_format: "%Y-%m-%dT%H:%M:%S"
-        - name: /var/log/dpkg.log
-          file: /var/log/dpkg.log
-          log_group_name: /var/log/dpkg.log
-          log_stream_name: "{{instance_id}}"
-          initial_position: start_of_file
-          datetime_format: "%Y-%m-%dT%H:%M:%S"
-        - name: /var/log/syslog
-          file: /var/log/syslog
-          log_group_name: /var/log/syslog
-          log_stream_name: "{{instance_id}}"
-          initial_position: start_of_file
-          datetime_format: "%Y-%m-%dT%H:%M:%S"
+
 tags:
   environment: ((bosh_environment))
 variables:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removes `awslogs` from the runtime configuration for all BOSH directors
- Adds the job back to Tooling BOSH for now.  There is a cron job that relies on the AWS CLI being installed, and you guessed it, relies on the package included by this release.  I'll come up with a cut down bosh release later on for the AWS CLI but want to start rolling with this in the meantime.
- Part of https://github.com/cloud-gov/private/issues/2623

## security considerations
Removes duplicate platform logs that are also being sent to cloudwatch.
