### PR TITLE
Switch aws cli installation for cron job

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -250,7 +250,7 @@ jobs:
       - bosh-config/operations/add-cloud-gov-root-certificate.yml
       - bosh-config/operations/nats-payload.yml
       - bosh-config/operations/root-disk.yml
-      - bosh-config/operations/tooling-bosh-awslogs.yml
+      - bosh-config/operations/aws-cli-v2.yml
       vars_files:
       - bosh-config/variables/tooling.yml
       - terraform-secrets/terraform.yml

--- a/operations/aws-cli-v2.yml
+++ b/operations/aws-cli-v2.yml
@@ -1,0 +1,19 @@
+- type: replace
+  path: /instance_groups/name=bosh/jobs/-
+  value: 
+    name: pre-start-script
+    release: os-conf
+    properties:
+      script: |
+        #!/bin/bash
+        mkdir /var/vcap/data/aws-cli-v2
+        chown root:vcap /var/vcap/data/aws-cli-v2
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        unzip awscliv2.zip
+        ./aws/install --install-dir /var/vcap/data/aws-cli-v2
+
+- type: replace
+  path: /releases/-
+  value:
+    name: os-conf  
+    version: latest

--- a/operations/cron.yml
+++ b/operations/cron.yml
@@ -43,8 +43,7 @@
               # apps from other packages on this host we need
               PSQL=/var/vcap/packages/postgres-client/bin/psql
 
-              AWSCLI=/var/vcap/packages/awslogs-jammy/venv/bin/aws
-              export LD_LIBRARY_PATH=/var/vcap/packages/awslogs-jammy/venv/lib
+              AWSCLI=/var/vcap/data/aws-cli-v2/v2/current/bin/aws
 
               # Hack: look up push gateway address in database if gateway is managed by the current director
               if [ -n "${GATEWAY_DEPLOYMENT}" ]; then


### PR DESCRIPTION
## Changes proposed in this pull request:
- The script in `cron.yml` currently relies of the installation of the AWS CLI from the awslogs release, these is being deprecated so a replacement is needed.
- The package in awslogs leverages a deprecated version of python (3.7.5) to install the v1 version of the AWS CLI
- The new os-conf based solution installs the AWS CLI v2 which does not have the separate python dependency
- After testing, a later PR will remove the temporary ops file `tooling-bosh-awslogs.yml`
 - Part of https://github.com/cloud-gov/private/issues/2623

## security considerations
Removes older python from the bosh director and upgrades to a newer generation of the AWS CLI
