### PR TITLE
Add auth.log and dpkg.log to syslog via runtime config

### DIFF
--- a/runtime-config/runtime.yml
+++ b/runtime-config/runtime.yml
@@ -32,6 +32,24 @@ addons:
       syslog:
         address: ((terraform_outputs.platform_syslog_elb_dns_name))
         port: 5514
+        custom_rule: |
+          module(load="imfile" PollingInterval="10")
+
+          input(type="imfile"
+                File="/var/log/auth.log"
+                Tag="auth:"
+                Facility="local6"
+                Severity="info"
+                PersistStateInterval="200"
+                addMetadata="on")
+
+          input(type="imfile"
+                File="/var/log/dpkg.log"
+                Tag="dpkg:"
+                Facility="local6"
+                Severity="info"
+                PersistStateInterval="200"
+                addMetadata="on")
     release: syslog
   - name: aide
     release: aide


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add auth.log and dpkg.log to syslog since awslogs will no longer be doing this
- audit.log is omitted because those logs are already included in syslog.  Adding it is ignored since the messages already go to syslog.
- syslog is omitted because it is already included, adding it explicitly causes a snowball effect of the logging of syslog being recorded by syslog being recorded by syslog... until the syslog fills the disk and the vm falls over.  Sorry Jason. These logs already are in logs platform anyway.  
- Part of https://github.com/cloud-gov/private/issues/2623

## security considerations
Adds logging of required files to syslog that awslogs used to do
