### PR TITLE
Scale logs platform disk to 11TB

### DIFF
--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -86,7 +86,7 @@
   path: /disk_types/-
   value:
     name: logs_opensearch_os_platform_data
-    disk_size: 10_500_000
+    disk_size: 11_000_000
     cloud_properties:
       type: gp3
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:
- Scale logs platform disk to 11TB
- Currently alerting in Prometheus, disk at 83% on one node
- Part of https://github.com/cloud-gov/product/issues/2836

## security considerations
Scaling disk, low risk
