### PR TITLE
remove logsearch ingestor instance type from cloud config

### DIFF
--- a/cloud-config/base.yml
+++ b/cloud-config/base.yml
@@ -134,11 +134,6 @@ vm_types:
     instance_type: r6i.xlarge
     ephemeral_disk:
       size: 30000
-  name: r6i.xlarge.logsearch.ingestor
-- cloud_properties:
-    instance_type: r6i.xlarge
-    ephemeral_disk:
-      size: 30000
   name: r6i.xlarge.opensearch.ingestor
 - cloud_properties:
     instance_type: t3.2xlarge


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove logsearch ingestor instance type from cloud config
-
-

## security considerations

None. Logsearch is deprecated
